### PR TITLE
fix F2 detection in methods.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+### Changed
+- Fix F2 detection in Line 111 of methods.config
 
 ---
 

--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -108,7 +108,7 @@ methods {
                 }
             else {
                 // Check memory for F series node
-                if (node_memory_GB >= (node_cpus * 2 * 0.9) && node_memory_GB <= (node_cpus * 2)) {
+                if (node_memory_GB >= (node_cpus * 2 * 0.9 - 1) && node_memory_GB <= (node_cpus * 2)) {
                     includeConfig "${projectDir}/config/F${node_cpus}.config"
                     }
                 else {

--- a/pipeline/nextflow.config
+++ b/pipeline/nextflow.config
@@ -5,7 +5,7 @@ manifest {
     name = "call-sSV"
     mainScript = "call-sSV.nf"
     nextflowVersion = ">=20.07.1"
-    author = "Yu Pan, Ghouse Mohammed"
+    author = "Yu Pan, Ghouse Mohammed, Mohammed Faizal Eeman Mootor"
     homePage = "https://github.com/uclahs-cds/pipeline-call-sSV"
     description = "A pipeline to call somatic SVs utilizing Delly"
     version = "2.0.0"


### PR DESCRIPTION
# Description
Pipeline fails to run on an F2 node with A-mini test dataset. An error log was captured stating "system resources not as expected".

# Fix
Line 111 of methods.config was modified according to a similar issue from nextflow pipeline template - uclahs-cds/template-NextflowPipeline#59

### Closes #27 

## Testing Results

- DNA A-mini
    - sample:    A-mini S2.T-0
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-fix-F2-detection/input/tumor_control_pair_0.csv
    - config:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-fix-F2-detection/config/template.config
    - output:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-fix-F2-detection/


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStanda
rds-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one DNA A-mini sample and one A-full sample. The paths to the test config files and output directories were attached above. 
