### PR TITLE
Update Delly 0.9.1 to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+### Changed
+- Change Delly version from 0.9.1 to 1.0.3 in default.config
 ### Fixed
 - Fix memory allocation for process 'query_SampleName_BCFtools' in F2.config - Discussion #28 and PR #33
 - Fix F2 detection in methods.config - PR #32

--- a/pipeline/config/default.config
+++ b/pipeline/config/default.config
@@ -21,7 +21,7 @@ params {
     blcds_registered_dataset = false
 
     // Pipeline tool versions
-    delly_version = '0.9.1'
+    delly_version = '1.0.3'
     bcftools_version = '1.12'
     validate_version = '2.1.5'
 


### PR DESCRIPTION
# Description
This commit will upgrade Delly v0.9.1 to v1.0.3. No difference is observed in significant variant calls i.e. having good mapping quality, but runtime has increased with v1.0.3. 

## v0.9.1 vs v1.0.3
### Variant Calls
**1. SVs with Good Mapping Quality -** No differences in the SV calls were found between v0.9.1 and v1.0.3 for those variants with Mapping Quality (MAPQ) > 0

- `/hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/delly-0.9.1-vs-1.0.3_validation/A-mini_S2.T-0/delly0.9.1-vs-1.0.3_MAPQ_gt_zero_filtered.sha512`
- `/hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/delly-0.9.1-vs-1.0.3_validation/A-full_T5.T/delly0.9.1-vs-1.0.3_MAPQ_gt_zero_filtered.sha512`

**2. SVs with Bad Mapping Quality -** Differences were seen in the number of SVs called by v0.9.1 and v1.0.3 for only those variants with Mapping Quality (MAPQ) = 0. The difference in the number of variants called, appears to be predominantly due to the difference in the Quality Scores of these variants between v0.9.1 and v1.0.3.

- `/hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/delly-0.9.1-vs-1.0.3_validation/A-mini_S2.T-0/delly0.9.1-vs-1.0.3_difference_only_in_MAPQ_zero.txt`
- `/hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/delly-0.9.1-vs-1.0.3_validation/A-full_T5.T/delly0.9.1-vs-1.0.3_difference_only_in_MAPQ_zero.txt`

### Runtime with stringent filters applied
**A-mini**
- Delly v0.9.1 (F2 node) - 13m 33.9s
- Delly v1.0.3 (F2 node) - 20m 32s

**A-full**
- Delly v1.0.3 (F16 node) - 17h 53m 49s
- Delly v0.9.1 (F72 node) - 18h 16m 23.4s
- Delly v1.0.3 (F72 node) - 18h 16m 15s
- Delly v1.0.3 (F32 node) - 20h 14m 1s

**Real Sample - ILHNLNEV000001-T001-P01-F**
- Delly v1.0.3 (F16 node) - 8h 46m 31s
- Delly v0.8.7 (F32 node) - 8h 37m 34s
- Delly v1.0.3 (F32 node) - 9h 38m 29s

## Links
Delly v1.0.3 GitHub release - https://github.com/dellytools/delly/releases/tag/v1.0.3
BL CDS Docker Registry for Delly - https://hub.docker.com/repository/docker/blcdsdockerregistry/delly

### Closes #26

## Testing Results

- DNA A-mini
    - sample:    A-mini S2.T-0
    - **node type: F2**
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/input/tumor_control_pair_0.csv
    - config:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/config/A-mini-hg38.config
    - output:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/A-mini/call-sSV-2.0.0/S2.T-0/DELLY-1.0.3/output/
- DNA A-full
    - sample: T5.T
    - **node type: F16**
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-add-f1s-config/input/tumor_control_pair_afull.csv
    - config: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-add-F16-config/config/A-full-hg19.config
    - output: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-add-F16-config/A-full
- DNA A-full
    - sample:    A-full T5.T
    - **node type: F32**
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/input/tumor_control_pair_afull.csv
    - config:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/config/A-full-hg19.config
    - output:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/A-full/call-sSV-2.0.0/T5.T.sorted_py/DELLY-1.0.3/output/
- DNA A-full
    - sample:    A-full T5.T
    - **node type: F72**
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/input/tumor_control_pair_afull.csv
    - config:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/config/A-full-F72-hg19.config
    - output:    /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/A-full-F72/call-sSV-2.0.0/T5.T.sorted_py/DELLY-1.0.3/output/
- DNA Real Sample
    - sample: ILHNLNEV000001-T001-P01-F
    - **node type: F16**
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-add-F16-config/input/tumor_control_pair_ILHNLNEV000001-T001-P01-F.csv
    - config: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-add-F16-config/config/ILHNLNEV000001-T001-P01-F-hg38.config
    - output: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmootor-add-F16-config/ILHNLNEV000001-T001-P01-F/

- DNA Real Sample
    - sample: ILHNLNEV000001-T001-P01-F
    - **node type: F32**
    - input csv: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/input/tumor_control_pair_ILHNLNEV000001-T001-P01-F.csv
    - config: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/config/ILHNLNEV000001-T001-P01-F-F32-hg38.config
    - output: /hot/software/pipeline/pipeline-call-sSV/Nextflow/development/unreleased/mmoootor-upgrade-delly-0.9.1-to-1.0.3/ILHNLNEV000001-T001-P01-F-F32/call-sSV-2.0.0/ILHNLNEV000001-T001-P01-F_realigned_recalibrated_reheadered/DELLY-1.0.3/output/

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStanda
rds-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one DNA A-mini sample and one A-full sample. The paths to the test config files and output directories were attached above. 
