### PR TITLE
Update memory allocations in M64 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - Update PlantUML action to `v1.0.1`
+- Update memory allocations in `M64.config`
 
 ### Added
 - Add PlantUML diagram

--- a/config/F2.config
+++ b/config/F2.config
@@ -2,7 +2,7 @@ process {
     withName: run_validate_PipeVal {
         cpus = 1
         memory = 1.GB
-       }
+        }
 
     withName: call_sSV_Delly {
         cpus = 1

--- a/config/M64.config
+++ b/config/M64.config
@@ -6,7 +6,7 @@ process {
 
     withName: call_sSV_Delly {
         cpus = 1
-        memory = 30.GB
+        memory = 120.GB
         retry_strategy {
             memory {
                 strategy = 'exponential'
@@ -17,7 +17,7 @@ process {
 
     withName: filter_sSV_Delly {
         cpus = 1
-        memory = 30.GB
+        memory = 2.GB
         retry_strategy {
             memory {
                 strategy = 'exponential'


### PR DESCRIPTION
# Description

This PR will update the default memory allocations of the M64 config. 

Delly required ~85GB - ~100GB to process samples in `/hot/data/unregistered/Luo-Yamaguchi-PRAD-SHCV` and the current config won't work even with retry. I also suggest reducing the memory allocation of `filter_sSV_Delly` to 2GB or even lower unless we've seen any edge cases that require more memory. Also, `query_SampleName_BCFtools` wouldn't require 30GB.

### Closes #160 

## Pipeline Results

`/hot/data/unregistered/Luo-Yamaguchi-PRAD-SHCV/call-sSV-6.1.0/LYPRSHCV000001-T001-P01-F/log-call-sSV-6.1.0-20240505T053137Z/nextflow-log/trace.txt`

## Testing Results

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample with `algorithm = ['delly', 'manta']`. The paths to the test config files and output directories are attached above.
