### PR TITLE
Mask version number in config tests

### DIFF
--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -30,6 +30,14 @@
     "trace.file",
     "params.date"
   ],
+  "version_fields": [
+    "manifest.version",
+    "params.log_output_dir",
+    "params.output_dir_base",
+    "report.file",
+    "timeline.file",
+    "trace.file"
+  ],
   "expected_result": {
     "docker": {
       "all_group_ids": "$(for i in `id --real --groups`; do echo -n \"--group-add=$i \"; done)",
@@ -41,7 +49,7 @@
       "author": "Yu Pan, Ghouse Mohammed, Mohammed Faizal Eeman Mootor",
       "description": "A pipeline to call somatic SVs utilizing Delly and Manta",
       "name": "call-sSV",
-      "version": "6.1.0"
+      "version": "VER.SI.ON"
     },
     "params": {
       "algorithm": [
@@ -72,7 +80,7 @@
           ]
         }
       },
-      "log_output_dir": "/tmp/outputs/call-sSV-6.1.0/610093/log-call-sSV-6.1.0-19970704T165655Z",
+      "log_output_dir": "/tmp/outputs/call-sSV-VER.SI.ON/610093/log-call-sSV-VER.SI.ON-19970704T165655Z",
       "mad_cutoff": "15",
       "manta_version": "1.6.0",
       "map_qual": "20",
@@ -82,7 +90,7 @@
       "min_cpus": "1",
       "min_memory": "1 MB",
       "output_dir": "/tmp/outputs",
-      "output_dir_base": "/tmp/outputs/call-sSV-6.1.0/610093",
+      "output_dir_base": "/tmp/outputs/call-sSV-VER.SI.ON/610093",
       "pipeval_version": "4.0.0-rc.2",
       "proc_resource_params": {
         "call_sSV_Delly": {
@@ -268,18 +276,18 @@
     },
     "report": {
       "enabled": true,
-      "file": "/tmp/outputs/call-sSV-6.1.0/610093/log-call-sSV-6.1.0-19970704T165655Z/nextflow-log/report.html"
+      "file": "/tmp/outputs/call-sSV-VER.SI.ON/610093/log-call-sSV-VER.SI.ON-19970704T165655Z/nextflow-log/report.html"
     },
     "sample": [
       "610093"
     ],
     "timeline": {
       "enabled": true,
-      "file": "/tmp/outputs/call-sSV-6.1.0/610093/log-call-sSV-6.1.0-19970704T165655Z/nextflow-log/timeline.html"
+      "file": "/tmp/outputs/call-sSV-VER.SI.ON/610093/log-call-sSV-VER.SI.ON-19970704T165655Z/nextflow-log/timeline.html"
     },
     "trace": {
       "enabled": true,
-      "file": "/tmp/outputs/call-sSV-6.1.0/610093/log-call-sSV-6.1.0-19970704T165655Z/nextflow-log/trace.txt"
+      "file": "/tmp/outputs/call-sSV-VER.SI.ON/610093/log-call-sSV-VER.SI.ON-19970704T165655Z/nextflow-log/trace.txt"
     },
     "tz": "sun.util.calendar.ZoneInfo[id=\"UTC\",offset=0,dstSavings=0,useDaylight=false,transitions=0,lastRule=null]",
     "workDir": "/scratch/523557"


### PR DESCRIPTION
# Description
This updates the Nextflow configuration regression tests to use the new feature from https://github.com/uclahs-cds/tool-Nextflow-action/pull/40 and mask the version numbers. This should ensure that we never need to "fix" the tests by updating the versions ever again.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample with `run_delly = true`, `run_manta = true`, `run_qc = true`. For `run_delly = true`, I have tested 'variant_type' set to `gSV`, `gCNV`, and both. The paths to the test config files and output directories are captured above in the Testing Results section.
