### PR TITLE
Update cluster reference paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ input:
 | dataset_id |	yes	| string |	Boutros Lab dataset id |
 | blcds_registered_dataset	| yes |	boolean | Affirms if dataset should be registered in the Boutros Lab Data registry. Default value is `false`. |
 | algorithm | yes | list | List containing a combination of SV callers `delly`, `manta`. List can contain a single caller of choice.  |
-| reference_fasta	| yes |	path	| Absolute path to the reference genome FASTA file. The reference genome is used by Delly for structural variant calling. GRCh37 - /hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa, GRCh38 - /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta |
-| exclusion_file |	yes	| path | Absolute path to the Delly reference genome exclusion file utilized to remove suggested regions for structural variant calling. GRCh37 - /hot/ref/tool-specific-input/Delly/GRCh37-EBI-hs37d/human.hs37d5.excl.tsv, GRCh38 - /hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv |
+| reference_fasta	| yes |	path	| Absolute path to the reference genome FASTA file. The reference genome is used by Delly for structural variant calling. GRCh37 - /hot/resource/reference-genome/GRCh37-EBI-hs37d5/hs37d5.fa, GRCh38 - /hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta |
+| exclusion_file |	yes	| path | Absolute path to the Delly reference genome exclusion file utilized to remove suggested regions for structural variant calling. GRCh37 - /hot/resource/tool-specific-input/Delly/GRCh37-EBI-hs37d/human.hs37d5.excl.tsv, GRCh38 - /hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv |
 | map_qual | yes | integer | Minimum paired-end (PE) mapping quality (MAPQ) for Delly. Default set to 20.|
 | min_clique_size | yes | integer | Minimum number of supporting PE or split-read (SR) alignments required for a clique to be identified as a structural variant by Delly. Adjust this parameter to control the sensitivity and specificity of Delly variant calling. Default set to 5.|
 | mad_cutoff | yes | integer | Insert size cutoff, median+s*MAD (deletions only) for Delly. Default set to 15.|

--- a/config/template.config
+++ b/config/template.config
@@ -11,13 +11,13 @@ params {
 
     blcds_registered_dataset = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-    // GRCh37 blacklist - /hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh37-EBI-hs37d5/ENCFF001TDO.bed
-    // GRCh38 blacklist - /hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed
-    gridss_blacklist = "/hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed"
-    gridss_reference_fasta = "/hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    // GRCh37 blacklist - /hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh37-EBI-hs37d5/ENCFF001TDO.bed
+    // GRCh38 blacklist - /hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed
+    gridss_blacklist = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed"
+    gridss_reference_fasta = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 
     output_dir = "where/to/save/outputs/"
 

--- a/test/config/ssv-all-tools.config
+++ b/test/config/ssv-all-tools.config
@@ -11,9 +11,9 @@ params {
 
     blcds_registered_dataset = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 
     // select the tool(s) to run
     algorithm = ['delly', 'manta']

--- a/test/config/ssv-delly.config
+++ b/test/config/ssv-delly.config
@@ -11,9 +11,9 @@ params {
 
     blcds_registered_dataset = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 
     // select the tool(s) to run
     algorithm = ['delly']

--- a/test/config/ssv-manta.config
+++ b/test/config/ssv-manta.config
@@ -11,9 +11,9 @@ params {
 
     blcds_registered_dataset = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 
     // select the tool(s) to run
     algorithm = ['manta']

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -68,7 +68,7 @@
       "docker_image_delly": "ghcr.io/uclahs-cds/delly:1.2.6",
       "docker_image_manta": "ghcr.io/uclahs-cds/manta:1.6.0",
       "docker_image_validate": "ghcr.io/uclahs-cds/pipeval:4.0.0-rc.2",
-      "exclusion_file": "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
+      "exclusion_file": "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
       "filter_condition": "FILTER=\\='PASS'",
       "input": {
         "BAM": {
@@ -138,7 +138,7 @@
           "memory": "1 GB"
         }
       },
-      "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "sample": "610093",
       "sample_id": "TWGSAMIN000001",
       "samples_to_process": [


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                                                      |                    | Updated                                                                                            |                    |
|-----------------------------------------------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                         | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                  | :white_check_mark: |
| `/hot/ref/reference/GRCh37-EBI-hs37d5/hs37d5.fa`                                              | :white_check_mark: | `/hot/resource/reference-genome/GRCh37-EBI-hs37d5/hs37d5.fa`                                       | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv`                                 | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv`                                 | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/GRCh37-EBI-hs37d/human.hs37d5.excl.tsv`                   | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/GRCh37-EBI-hs37d/human.hs37d5.excl.tsv`                   | :white_check_mark: |
| `/hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh37-EBI-hs37d5/ENCFF001TDO.bed`                | :white_check_mark: | `/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh37-EBI-hs37d5/ENCFF001TDO.bed`                | :white_check_mark: |
| `/hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed`               | :white_check_mark: | `/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed`               | :white_check_mark: |
| `/hot/ref/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: | `/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: |