### PR TITLE
Fix NFTest cases, re-enable config test workflows

### DIFF
--- a/.github/workflows/nextflow-tests.yaml
+++ b/.github/workflows/nextflow-tests.yaml
@@ -1,14 +1,21 @@
 ---
-name: Nextflow Tests
+name: Nextflow config tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_run:
+    workflows: [Trigger Tests]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  packages: read
+  pull-requests: write
+  statuses: write
 
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: uclahs-cds/tool-Nextflow-action/.github/workflows/nextflow-tests.yml@main
+    secrets: inherit

--- a/.github/workflows/trigger-tests.yaml
+++ b/.github/workflows/trigger-tests.yaml
@@ -1,0 +1,20 @@
+---
+name: Trigger tests
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  check-user:
+    uses: uclahs-cds/tool-Nextflow-action/.github/workflows/test-setup.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add GRIDSS2 preprocessing
 - Add supported Nextflow version to `README.md`
 - Add PlantUML diagram
+- Add call to `store_object_as_json` to store parameters
 
 ### Changed
 - Update PlantUML action to `v1.0.1`
 - Update memory allocations in `M64.config`
+- Re-enable configuration testing workflows
+
+### Fixed
+- Fix NFTest cases after GRIDSS2 additions
+- Fix configuration tests after GRIDSS2 additions
 
 ---
 

--- a/config/methods.config
+++ b/config/methods.config
@@ -3,6 +3,7 @@ includeConfig "../external/pipeline-Nextflow-config/config/bam/bam_parser.config
 includeConfig "../external/pipeline-Nextflow-config/config/methods/common_methods.config"
 includeConfig "../external/pipeline-Nextflow-config/config/schema/schema.config"
 includeConfig "../external/pipeline-Nextflow-config/config/retry/retry.config"
+includeConfig "${projectDir}/external/pipeline-Nextflow-config/config/store_object_as_json/store_object_as_json.config"
 
 methods {
     set_ids_from_bams = {
@@ -87,5 +88,10 @@ methods {
         methods.set_process()
         retry.setup_retry()
         methods.setup_docker_cpus()
+
+        json_extractor.store_object_as_json(
+            params,
+            new File("${params.log_output_dir}/params.json")
+        )
         }
     }

--- a/test/config/ssv-all-tools.config
+++ b/test/config/ssv-all-tools.config
@@ -12,6 +12,8 @@ params {
     blcds_registered_dataset = false
 
     reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    gridss_reference_fasta = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    gridss_blacklist = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed"
 
     exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 

--- a/test/config/ssv-delly.config
+++ b/test/config/ssv-delly.config
@@ -12,6 +12,8 @@ params {
     blcds_registered_dataset = false
 
     reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    gridss_reference_fasta = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    gridss_blacklist = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed"
 
     exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 

--- a/test/config/ssv-manta.config
+++ b/test/config/ssv-manta.config
@@ -12,6 +12,8 @@ params {
     blcds_registered_dataset = false
 
     reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    gridss_reference_fasta = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    gridss_blacklist = "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed"
 
     exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -66,10 +66,14 @@
       "docker_container_registry": "ghcr.io/uclahs-cds",
       "docker_image_bcftools": "ghcr.io/uclahs-cds/bcftools:1.15.1",
       "docker_image_delly": "ghcr.io/uclahs-cds/delly:1.2.6",
+      "docker_image_gridss": "ghcr.io/uclahs-cds/gridss:2.13.2",
       "docker_image_manta": "ghcr.io/uclahs-cds/manta:1.6.0",
       "docker_image_validate": "ghcr.io/uclahs-cds/pipeval:4.0.0-rc.2",
       "exclusion_file": "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
       "filter_condition": "FILTER=\\='PASS'",
+      "gridss_blacklist": "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed",
+      "gridss_reference_fasta": "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "gridss_version": "2.13.2",
       "input": {
         "BAM": {
           "normal": [
@@ -89,6 +93,7 @@
       "min_clique_size": "5",
       "min_cpus": "1",
       "min_memory": "1 MB",
+      "other_jvm_heap": "4 GB",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-sSV-VER.SI.ON/610093",
       "pipeval_version": "4.0.0-rc.2",
@@ -96,6 +101,16 @@
         "call_sSV_Delly": {
           "cpus": "1",
           "memory": "16 GB",
+          "retry_strategy": {
+            "memory": {
+              "operand": "2",
+              "strategy": "exponential"
+            }
+          }
+        },
+        "call_sSV_GRIDSS": {
+          "cpus": "8",
+          "memory": "15 GB",
           "retry_strategy": {
             "memory": {
               "operand": "2",
@@ -123,9 +138,29 @@
             }
           }
         },
+        "preprocess_BAM_GRIDSS": {
+          "cpus": "4",
+          "memory": "10 GB",
+          "retry_strategy": {
+            "memory": {
+              "operand": "2",
+              "strategy": "exponential"
+            }
+          }
+        },
         "query_SampleName_BCFtools": {
           "cpus": "1",
           "memory": "3 GB",
+          "retry_strategy": {
+            "memory": {
+              "operand": "2",
+              "strategy": "exponential"
+            }
+          }
+        },
+        "run_assembly_GRIDSS": {
+          "cpus": "8",
+          "memory": "15 GB",
           "retry_strategy": {
             "memory": {
               "operand": "2",
@@ -242,6 +277,15 @@
           "closure": "retry_updater(16 GB, exponential, 2, $task.attempt, memory)"
         }
       },
+      "withName:call_sSV_GRIDSS": {
+        "cpus": "8",
+        "memory": {
+          "1": "15 GB",
+          "2": "30 GB",
+          "3": "31 GB",
+          "closure": "retry_updater(15 GB, exponential, 2, $task.attempt, memory)"
+        }
+      },
       "withName:call_sSV_Manta": {
         "cpus": "1",
         "memory": {
@@ -260,6 +304,15 @@
           "closure": "retry_updater(3 GB, exponential, 2, $task.attempt, memory)"
         }
       },
+      "withName:preprocess_BAM_GRIDSS": {
+        "cpus": "4",
+        "memory": {
+          "1": "10 GB",
+          "2": "20 GB",
+          "3": "31 GB",
+          "closure": "retry_updater(10 GB, exponential, 2, $task.attempt, memory)"
+        }
+      },
       "withName:query_SampleName_BCFtools": {
         "cpus": "1",
         "memory": {
@@ -267,6 +320,15 @@
           "2": "6 GB",
           "3": "12 GB",
           "closure": "retry_updater(3 GB, exponential, 2, $task.attempt, memory)"
+        }
+      },
+      "withName:run_assembly_GRIDSS": {
+        "cpus": "8",
+        "memory": {
+          "1": "15 GB",
+          "2": "30 GB",
+          "3": "31 GB",
+          "closure": "retry_updater(15 GB, exponential, 2, $task.attempt, memory)"
         }
       },
       "withName:run_validate_PipeVal": {


### PR DESCRIPTION
# Description
This PR accomplishes a bunch of testing-related fixes:

* Adds missing parameters to NFTest config files (closes #188)
* Adds in call to `store_object_as_json` to save parameters (closes #170)
* Updates the config test workflows (closes #149)
* Updates the config test to account for the GRIDSS changes

## Testing Results

All NFTest cases passed:

`/hot/software/pipeline/pipeline-call-sSV/Nextflow/development/6.1.0/nwiltsie-save-params/log-nftest-20241209T183314Z.log`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample with `algorithm = ['delly', 'manta']`. The paths to the test config files and output directories are attached above.
