### PR TITLE
Update plotting to paramterize genome build

### DIFF
--- a/config/default.config
+++ b/config/default.config
@@ -16,6 +16,8 @@ params {
     min_cpus = 1
     min_memory = 1.MB
 
+    genome_build = 'hg38'
+
     other_jvm_heap = 4.GB
 
     cache_intermediate_pipeline_steps = false

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -35,6 +35,13 @@ algorithm:
     - delly
     - manta
     - gridss2
+genome_build:
+  type: 'String'
+  required: true
+  help: 'Genome build'
+  choices:
+    - hg19
+    - hg38
 output_dir:
   type: 'Path'
   mode: 'w'

--- a/main.nf
+++ b/main.nf
@@ -201,7 +201,6 @@ workflow {
             .map{ it.toString() }
             .filter{ it.endsWith("candidateSV.vcf.gz") }
             .map{ ['Manta', it] }
-            .view{ "HERE: $it" }
             .set{ input_ch_plot_manta }
 
         plot_MantaSV_circlize(

--- a/module/circos-plot.nf
+++ b/module/circos-plot.nf
@@ -51,6 +51,7 @@ process plot_SV_circlize {
             --sv.caller "${caller}" \
             --plot.title TRUE \
             --output.filename "${output_filename}.png" \
-            --script.source "${projectDir}/script/CIRCOS"
+            --script.source "${projectDir}/script/CIRCOS" \
+            --genome.build ${params.genome_build}
     """
 }

--- a/script/CIRCOS/circos-plot-setup.R
+++ b/script/CIRCOS/circos-plot-setup.R
@@ -6,6 +6,29 @@
 
 
 ### FUNCTIONS ######################################################################################
+## Function: detect.and.fix.chr.format -------------------------------------------------------------
+# Description: Auto-detect and fix chromosome format differences
+# Input: df (dataframe) - dataframe with 'chr.start' and 'chr.end' columns
+# Output: df (dataframe) - dataframe with 'chr.start' and 'chr.end' columns adjusted to match circos format
+detect.and.fix.chr.format <- function(df) {
+    # Check if [first] chr in data is in an acceptable format
+    if (!is.character(df$chr.start[1]) || is.na(df$chr.start[1])) {
+        warning('Invalid chromosome names or class in data')
+        return(df);
+        }
+
+    # Check if chr formats are matching
+    has.chr.prefix.data <- grepl('^chr', df$chr.start[1]);
+
+    # Circos expects chr prefix
+    if (!has.chr.prefix.data) {
+        df$chr.start <- paste0('chr', df$chr.start);
+        df$chr.end <- paste0('chr', df$chr.end);
+        }
+
+    return(df)
+    }
+
 ## Function: get.InsInvBnd.df ----------------------------------------------------------------------
 # Description: This function takes in a BED data frame with 'INV', 'BND', and 'INS' SV types and
     # returns a list containing two modified BED data frames, insinvbnd.bed1 and insinvbnd.bed2,
@@ -46,16 +69,18 @@ get.InsInvBnd.df <- function(sample.sv.df) {
     ins.inv.bnd.lwd <- rep(2, nrow(ins.inv.bnd.df));
     ins.inv.bnd.lty <- rep(1, nrow(ins.inv.bnd.df));
 
-    return(
-        list(
-            ins.inv.bnd.bed1,
-            ins.inv.bnd.bed2,
-            ins.inv.bnd.col,
-            ins.inv.bnd.lwd,
-            ins.inv.bnd.lty
-            )
+    list.results <- list(
+        ins.inv.bnd.bed1,
+        ins.inv.bnd.bed2,
+        ins.inv.bnd.col,
+        ins.inv.bnd.lwd,
+        ins.inv.bnd.lty
         );
+
+    names(list.results) <- c('bed1','bed2','cols','lwds','ltys');
+    return(list.results);
     }
+
 
 
 ### CIRCOS FUNCTIONS ###############################################################################
@@ -118,10 +143,6 @@ CIRCLIZE.SETUP <- function(species = 'hg38') {
     circos.par('start.degree' = 90);
     circos.par('gap.degree' = rep(c(2), 24));
     circos.initializeWithIdeogram(plotType = NULL, species = species);
-    # circos.initializeWithIdeogram(
-    #     species = 'hg38',
-    #     chromosome.index = paste0('chr', c(1:22, 'X', 'Y'))
-    #     );
     }
 
 ## Function: CIRCLIZE.CHROMOSOME.LAYOUT ------------------------------------------------------------

--- a/script/CIRCOS/final-plotting.R
+++ b/script/CIRCOS/final-plotting.R
@@ -114,12 +114,12 @@ if (nrow(bnd.df) > 0) {
             bnd.df$end[i] <- endpos;
 
             # Extract text between bracket and colon
-            match <- regexec("[][\\[](.*?):", chr.end)
+            match <- regexec("[][\\[](.*?):", chr.end); # nolint
             chr.num <- regmatches(chr.end, match)[[1]][2];
 
             # Apply chr prefix based on chr.start
             has.chr.prefix <- grepl('^chr', bnd.df$chr.start[i])
-            bnd.df$chr.end[i] <- if(has.chr.prefix) paste0('chr', chr.num) else chr.num
+            bnd.df$chr.end[i] <- if (has.chr.prefix) paste0('chr', chr.num) else chr.num
             }
         }
     }

--- a/script/CIRCOS/final-plotting.R
+++ b/script/CIRCOS/final-plotting.R
@@ -21,6 +21,7 @@ parser$add_argument('--sample.name', type = 'character', help = 'Sample name', r
 parser$add_argument('--script.source', type = 'character', help = 'Path to directory containing helper scripts', required = TRUE);
 parser$add_argument('--sv.caller', type = 'character', help = 'Either Delly, Manta, or SURVIVOR verbatim', default = 'Delly');
 parser$add_argument('--plot.title', type = 'logical', help = 'print a title? TRUE or FALSE', default = TRUE);
+parser$add_argument('--genome.build', type = 'character', help = 'Genome build (e.g. hg38, hg19)', default = 'hg38');
 
 # Parse the command-line arguments
 args <- parser$parse_args();
@@ -35,6 +36,7 @@ cna.caller <- args$cna.caller;
 output.type <- args$output.type;
 plot.title <- args$plot.title;
 script.source <- args$script.source;
+genome.build <- args$genome.build;
 
 # Print the values of the variables
 cat('Input SV file:', input.vcf, '\n');
@@ -45,6 +47,7 @@ cat('Output Filename:', output.filename, '\n');
 cat('SV caller:', sv.caller, '\n');
 cat('CNA caller:', cna.caller, '\n');
 cat('Plot title:', plot.title, '\n');
+cat('Genome build:', genome.build, '\n');
 
 source(paste0(script.source, '/convert-manta-to-circlize.R'));
 source(paste0(script.source, '/convert-delly-to-circlize.R'));
@@ -100,10 +103,31 @@ ins.df <- otherSV.df[otherSV.df$type == 'INS', ];
 trans.df <- otherSV.df[otherSV.df$type == 'TRA',];
 bnd.df <- bnd.df.unfiltered[bnd.df.unfiltered$type == 'BND', ];
 
+# Fix BND chromosome formats
+if (nrow(bnd.df) > 0) {
+    for (i in 1:nrow(bnd.df)) {
+        chr.end <- bnd.df$chr.end[i];
+
+        if (grepl(':', chr.end)) {
+            # Extract position after the colon
+            endpos <- as.numeric(sub('.*:(\\d+).*', '\\1', chr.end));
+            bnd.df$end[i] <- endpos;
+
+            # Extract text between bracket and colon
+            match <- regexec("[][\\[](.*?):", chr.end)
+            chr.num <- regmatches(chr.end, match)[[1]][2];
+
+            # Apply chr prefix based on chr.start
+            has.chr.prefix <- grepl('^chr', bnd.df$chr.start[i])
+            bnd.df$chr.end[i] <- if(has.chr.prefix) paste0('chr', chr.num) else chr.num
+            }
+        }
+    }
+
 # To distinguish INV and BND from Manta, if chr.start == chr.end, this is INV
 bnd.df$type[bnd.df$chr.start == bnd.df$chr.end] <- 'INV';
 
-# rbind() dataframes so the data for otherSV and BNDs are combined
+# Combine all SVs (BNDs and other SVs)
 sample.df <- rbind(
     dup.df,
     del.df,
@@ -113,9 +137,9 @@ sample.df <- rbind(
     bnd.df
     );
 
-# Remove SVs that have 'random' or 'decoy' in the chromosome name
-sample.df <- subset(sample.df, !grepl('random|decoy|alt|Un', chr.start));
-sample.df <- subset(sample.df, !grepl('random|decoy|alt|Un', chr.end));
+# Filter for standard chromosomes, but keep BNDs
+sample.df <- sample.df[grepl('^(chr|)[0-9XY]+$', sample.df$chr.start), ];
+sample.df <- sample.df[grepl('^(chr|)[0-9XY]+$', sample.df$chr.end), ];
 
 print('Successfully processed SV file')
 
@@ -142,8 +166,12 @@ layout(matrix(c(1, 2), nrow = 2), heights = c(3, 0.4));
 
 # Plot circos plot
 par(mar = c(0, 1, 1, 1));
-CIRCLIZE.SETUP();
+CIRCLIZE.SETUP(species = genome.build);
 CIRCLIZE.CHROMOSOME.LAYOUT();
+
+# Check and fix chromosome format for consistent chr naming
+sample.df <- detect.and.fix.chr.format(sample.df);
+
 list.of.InsInvBnd <- get.InsInvBnd.df(sample.df);
 CIRCLIZE.INSINVBND(insinvbnd.list = list.of.InsInvBnd);
 

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -73,6 +73,7 @@
       "docker_image_validate": "ghcr.io/uclahs-cds/pipeval:4.0.0-rc.2",
       "exclusion_file": "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
       "filter_condition": "FILTER=\\='PASS'",
+      "genome_build": "hg38",
       "gridss_blacklist": "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/ENCFF356LFX.bed",
       "gridss_reference_fasta": "/hot/resource/tool-specific-input/GRIDSS-2.13.2/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "gridss_version": "2.13.2",


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Parameterizing genome build and updating plotting scripts accordingly.

## Testing Results
NFTest:
- Case: `ssv-manta-std-input`
- Log: `/hot/software/pipeline/pipeline-call-sSV/Nextflow/development/6.1.0/yashpatel-update-plotting/log-nftest-20250305T210935Z.log`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample with `algorithm = ['delly', 'manta']`. The paths to the test config files and output directories are attached above.
